### PR TITLE
Removed several warnings when compiling with GCC 10.2

### DIFF
--- a/include/stxxl/bits/common/comparator.h
+++ b/include/stxxl/bits/common/comparator.h
@@ -364,14 +364,14 @@ public:
 
     ValueType min_value() const
     {
-        ValueType result;
+        ValueType result{};
         keys(result) = impl.min_value();
         return result;
     }
 
     ValueType max_value() const
     {
-        ValueType result;
+        ValueType result{};
         keys(result) = impl.max_value();
         return result;
     }

--- a/include/stxxl/bits/containers/vector.h
+++ b/include/stxxl/bits/containers/vector.h
@@ -598,8 +598,8 @@ public:
     //! \}
 
 protected:
-    blocked_index_type offset;
-    const vector_type* p_vector;
+    blocked_index_type offset{0};
+    const vector_type* p_vector{nullptr};
 
 private:
     //! private constructor for initializing other iterators
@@ -609,13 +609,12 @@ private:
 
 public:
     //! constructs invalid iterator
-    const_vector_iterator()
-        : offset(0), p_vector(nullptr)
-    { }
+    const_vector_iterator() = default;
     //! copy-constructor
-    const_vector_iterator(const const_vector_iterator& a)
-        : offset(a.offset), p_vector(a.p_vector)
-    { }
+    const_vector_iterator(const const_vector_iterator& a) = default;
+    //! copy-assignment-operator
+    const_vector_iterator& operator=(const const_vector_iterator& a) = default;
+
     //! implicit conversion from mutable iterator
     const_vector_iterator(const mutable_self_type& a) // NOLINT
         : offset(a.offset), p_vector(a.p_vector)

--- a/tools/benchmark_pqueue.cpp
+++ b/tools/benchmark_pqueue.cpp
@@ -47,9 +47,9 @@ using stxxl::external_size_type;
 
 // *** Integer Pair Types
 
-using uint32_pair_type = std::tuple<uint32_t, uint32_t>;
+using uint32_pair_type = std::array<uint32_t, 2>;
 
-using uint64_pair_type = std::tuple<uint64_t, uint64_t>;
+using uint64_pair_type = std::array<uint64_t, 2>;
 
 // *** Larger Structure Type
 
@@ -63,7 +63,7 @@ struct my_type
 
     my_type() { }
     my_type(const key_type& k1, const key_type& k2)
-        : uint32_pair_type(k1, k2)
+        : uint32_pair_type{k1, k2}
     { }
 };
 
@@ -77,16 +77,6 @@ struct tuple_element<0, my_type>
 
 } // namespace std
 
-template <typename ValueType, size_t mem_for_queue, external_size_type maxvolume>
-struct my_pq_gen
-{
-    using type = typename stxxl::PRIORITY_QUEUE_GENERATOR<
-              ValueType,
-              stxxl::comparator<ValueType, stxxl::direction::Greater, stxxl::direction::DontCare>,
-              mem_for_queue,
-              maxvolume* MiB / sizeof(ValueType)>;
-};
-
 struct my_type_extractor
 {
     template <typename T>
@@ -96,14 +86,14 @@ struct my_type_extractor
     }
 };
 
-template <size_t mem_for_queue, external_size_type maxvolume>
-struct my_pq_gen<my_type, mem_for_queue, maxvolume>
+template <typename ValueType, size_t mem_for_queue, external_size_type maxvolume>
+struct my_pq_gen
 {
     using type = typename stxxl::PRIORITY_QUEUE_GENERATOR<
-              my_type,
-              stxxl::struct_comparator<my_type, my_type_extractor, stxxl::direction::Greater>,
+              ValueType,
+              stxxl::struct_comparator<ValueType, my_type_extractor, stxxl::direction::Greater>,
               mem_for_queue,
-              maxvolume* MiB / sizeof(my_type)>;
+              maxvolume* MiB / sizeof(ValueType)>;
 };
 
 static inline void progress(const char* text, external_size_type i, external_size_type nelements)
@@ -135,7 +125,7 @@ void run_pqueue_insert_delete(external_size_type nelements, size_t mem_for_pools
         {
             progress("Inserting element", i, nelements);
 
-            pq.push(ValueType(static_cast<KeyType>(nelements - i), 0));
+            pq.push(ValueType{static_cast<KeyType>(nelements - i), 0});
         }
     }
 
@@ -187,7 +177,7 @@ void run_pqueue_insert_intermixed(external_size_type nelements, size_t mem_for_p
         {
             progress("Inserting element", i, nelements);
 
-            pq.push(ValueType(static_cast<KeyType>(nelements - i), 0));
+            pq.push(ValueType{static_cast<KeyType>(nelements - i), 0});
         }
     }
 
@@ -209,7 +199,7 @@ void run_pqueue_insert_intermixed(external_size_type nelements, size_t mem_for_p
         {
             if (distr(rand) == 0)
             {
-                pq.push(ValueType(static_cast<KeyType>(nelements - i), 0));
+                pq.push(ValueType{static_cast<KeyType>(nelements - i), 0});
             }
             else
             {


### PR DESCRIPTION
- stxxl::priority_queue uses std::memmove internally, which is only defined behavior for trivially copyable types.
  std::pair and std::tuple are not trivially copyable, even if all the stored types are trivially copyable, so storing
  them in a stxxl::priority_queue is technically undefined behavior. While this should still work as expected in all "sane"
  compilers, it is still against the standard and GCC 10.2 throws a warning. This commit fixes the only occurence of this warning
  in the "core" libraries stxxl and stxxl_tools. Note that there are many more occurences of this issues in the examples
  (e.g. in the skew3 algorithm) which remain unchanged by this commit.

- stxxl::vector::const_vector_iterator had a user-defined copy-constructor but the automatically generated copy-assignment-operator.
  This throws a warning in GCC 10.2 (Typically, either both can be defaulted, or both have to be manually defined). The const_vector_iterator
  is a trivial type, so defaulting both operations works here and leads to a cleaner interface.